### PR TITLE
Adds S3 encryption by default when writing with pathio

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,64 @@ Note that using s3 paths requires setting two environment variables
 
 ## Usage
 
+```go
+var DefaultClient = &Client{}
+```
+DefaultClient is the default pathio client called by the Reader, Writer, and
+WriteReader methods. It has S3 encryption enabled.
+
 #### func  Reader
 
 ```go
 func Reader(path string) (rc io.ReadCloser, err error)
 ```
-Reader returns an io.Reader for the specified path. The path can either be a
-local file path or an S3 path. It is the caller's responsibility to close rc.
+Reader Calls DefaultClient's Reader method.
 
 #### func  Write
 
 ```go
 func Write(path string, input []byte) error
 ```
-Write writes a byte array to the specified path. The path can be either a local
-file path or an S3 path.
+Write Calls DefaultClient's Write method.
 
 #### func  WriteReader
 
 ```go
 func WriteReader(path string, input io.ReadSeeker) error
+```
+WriteReader Calls DefaultClient's WriteReader method.
+
+#### type Client
+
+```go
+type Client struct {
+}
+```
+
+Client is the pathio client used to access the local file system and S3. It
+includes an option to disable S3 encryption. To disable S3 encryption, create a
+new Client and call it directly: `&Client{disableS3Encryption: true}.Write(...)`
+
+#### func (*Client) Reader
+
+```go
+func (c *Client) Reader(path string) (rc io.ReadCloser, err error)
+```
+Reader returns an io.Reader for the specified path. The path can either be a
+local file path or an S3 path. It is the caller's responsibility to close rc.
+
+#### func (*Client) Write
+
+```go
+func (c *Client) Write(path string, input []byte) error
+```
+Write writes a byte array to the specified path. The path can be either a local
+file path or an S3 path.
+
+#### func (*Client) WriteReader
+
+```go
+func (c *Client) WriteReader(path string, input io.ReadSeeker) error
 ```
 WriteReader writes all the data read from the specified io.Reader to the output
 path. The path can either a local file path or an S3 path.


### PR DESCRIPTION
This change introduces new behavior to encrypt data by default when writing to S3. This is accomplished by sending the `ServerSideEncryption` parameter with a value of `AES` when using the `aws-sdk-go` `s3` client.

In addition, we've introduced a new `Client` type that includes an option to disable this encryption. A `DefaultClient` variable, which will perform encryption, is called by the `Reader`, `Writer`, and `WriteReader` methods. A caller could create a new Client with the `disableS3Encryption` parameter set to `true` and call the `Reader`, `Writer`, and `WriteReader` methods directly to skip the S3 encryption.

For more information, see https://clever.atlassian.net/browse/INFRA-1210

cc @azylman @mohit @rgarcia @ericavonb 