### PR TITLE
Fix so that p3 runs as expected & added p3 to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _testmain.go
 
 *.exe
 *.test
+p3

--- a/cmd/p3.go
+++ b/cmd/p3.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"


### PR DESCRIPTION
This is a small fix so that that the p3 executable runs as expected, and that it is ignored by git.

Previously, the package specified for the `p3.go` file would cause the resulting p3 executable to not work. Changing the package to `main` fixes this.