### PR TITLE
IP-353 pathio streams using io pipes

### DIFF
--- a/pathio_test.go
+++ b/pathio_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -189,4 +190,18 @@ func TestS3FileWriterSuccessNoEncryption(t *testing.T) {
 	foundErr := writeToS3(s3Connection{&svc, bucket, key}, input, true)
 	assert.Equal(t, foundErr, nil)
 	svc.AssertExpectations(t)
+}
+
+func TestStreamToLocalFile(t *testing.T) {
+	fileName := "stream_text.txt"
+	text := "Hello World"
+	r, w := io.Pipe()
+	var err *error
+	streamToLocalFile(fileName, r, err)
+	w.Write([]byte(text))
+	w.Close()
+	assert.Nil(t, err)
+	fileBytes, fileErr := ioutil.ReadFile(fileName)
+	assert.NoError(t, fileErr)
+	assert.Equal(t, string(fileBytes), text)
 }


### PR DESCRIPTION
**[JIRA](https://clever.atlassian.net/browse/IP-353)**

** Overview: **
Motivated by logic implemented in `mongo-to-s3`, we've added a function which takes in a reader who's contents is continuously streamed to a path. The particular use case was streaming mongo data directly to s3.

Documentation was added to indicate the delicacy of this functionality. Not only is async, but it the function doesn't exist cleanly until the reader is closed.

** Testing: **

Verified both stream to s3 and locally works as expected.

Also added automated testing for the case of local file streaming.

