### PR TITLE
Go 1.7 -> 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include golang.mk
 SHELL := /bin/bash
 PKG = gopkg.in/Clever/pathio.v3
 PKGS := $(shell go list ./... | grep -v /vendor)
-$(eval $(call golang-version-check,1.7))
+$(eval $(call golang-version-check,1.8))
 .PHONY: build test
 
 build:

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   post:
   - cd $HOME && git clone --depth 1 -v git@github.com:clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-  - $HOME/ci-scripts/circleci/golang-install 1.7
+  - $HOME/ci-scripts/circleci/golang-install 1.8
   - mkdir -p $HOME/.go_workspace/src/gopkg.in/Clever/pathio.v3
   services:
   - docker


### PR DESCRIPTION
Uses Go 1.8 in Circle build and golang-version-check.
You were assigned as the most active recent contributor to this repo. If LGTY, please merge away! Else, please reassign and share the joy of Go 1.8, or ask in #golang if you have any questions.